### PR TITLE
PQErrorMsgFields is added 

### DIFF
--- a/source/derelict/pq/pq.d
+++ b/source/derelict/pq/pq.d
@@ -63,7 +63,7 @@ extern(C) {
     alias uint Oid;
     alias char pqbool;
     alias long pg_int64;
-    public import std.c.stdio : FILE;
+    public import core.stdc.stdio : FILE;
 
     enum PG_COPYRES_ATTRS       = 0x01;
     enum PG_COPYRES_TUPLES      = 0x02;

--- a/source/derelict/pq/pq.d
+++ b/source/derelict/pq/pq.d
@@ -197,6 +197,27 @@ extern(C) {
         PGresult* result;
     }
 
+    enum PQErrorMsgFields : int
+    {
+        PG_DIAG_SEVERITY =          'S',
+        PG_DIAG_SQLSTATE =          'C',
+        PG_DIAG_MESSAGE_PRIMARY =   'M',
+        PG_DIAG_MESSAGE_DETAIL =    'D',
+        PG_DIAG_MESSAGE_HINT =      'H',
+        PG_DIAG_STATEMENT_POSITION ='P',
+        PG_DIAG_INTERNAL_POSITION = 'p',
+        PG_DIAG_INTERNAL_QUERY =    'q',
+        PG_DIAG_CONTEXT =           'W',
+        PG_DIAG_SCHEMA_NAME =       's',
+        PG_DIAG_TABLE_NAME =        't',
+        PG_DIAG_COLUMN_NAME =       'c',
+        PG_DIAG_DATATYPE_NAME =     'd',
+        PG_DIAG_CONSTRAINT_NAME =   'n',
+        PG_DIAG_SOURCE_FILE =       'F',
+        PG_DIAG_SOURCE_LINE =       'L',
+        PG_DIAG_SOURCE_FUNCTION =   'R'
+    }
+
     extern( C ) nothrow {
         alias PQnoticeReceiver = void function( void*,PGresult* );
         alias PQnoticeProcessor = void function( void*,char* );


### PR DESCRIPTION
PQErrorMsgFields is used by PQresultErrorField

Source: /usr/include/postgresql/postgres_ext.h