### PR TITLE
change posix libpq.so to libpq.so.5

### DIFF
--- a/source/derelict/pq/dynload.d
+++ b/source/derelict/pq/dynload.d
@@ -554,6 +554,6 @@ private:
     else static if(Derelict_OS_Mac)
         enum libNames = "libpq.dylib";
     else static if(Derelict_OS_Posix)
-        enum libNames = "libpq.so";
+        enum libNames = "libpq.so.5";
     else
         static assert(0, "Need to implement PostgreSQL libNames for this operating system.");


### PR DESCRIPTION
Archlinux package `postgresql-libs` provides
```
usr/lib/libpq.so
usr/lib/libpq.so.5
usr/lib/libpq.so.5.13
```

but on ubuntu (including 22.04 yet to be released), `libpq5` only provides:
```
/usr/lib/x86_64-linux-gnu/libpq.so.5
/usr/lib/x86_64-linux-gnu/libpq.so.5.14
```
and `libpq-dev` - which also pulls in `libpq5` - is required to get the `/usr/lib/x86_64-linux-gnu/libpq.so` symlink.

Users are not expected to install `-dev` packages to use distributed software.

Ideally a user of this library would be able to specify the shared library name.